### PR TITLE
swapping group_by to group_by_exp to resolve issue #11

### DIFF
--- a/tags.html
+++ b/tags.html
@@ -4,7 +4,7 @@ title: Tags
 ---
 
 {% assign alldocs = site.documents %}
-{% assign alltags =  alldocs | map: 'tags' | join: ','  | split: ','  | group_by: tag %}
+{% assign alltags =  alldocs | map: 'tags' | join: ','  | split: ','  | group_by_exp: "tag","tag" %}
 
 <p>
   Articles on similar topics are grouped together by tags. Click on any tag to find all the articles 'tagged' with that tag.


### PR DESCRIPTION
**swapping group_by to group_by_exp to resolve issue #11 on windows where all tags are placed in a single group**

Hello,

I was able to restore the expected behaviour by substituting _group_by_ with _group_by_exp_.

On my machine, _group_by_ was not working as expected, 
all tags, including duplicates, were placed in a single group of items, which did not have a name.

Thanks

Mat